### PR TITLE
57 disable check when is down

### DIFF
--- a/src/controllers/CheckController.js
+++ b/src/controllers/CheckController.js
@@ -115,6 +115,21 @@ class CheckController {
     }
   }
 
+  static async enable(req, res) {
+    const { id } = req.params;
+
+    try {
+      const updateCheck = await CheckService.enable({id, user: req.user});
+
+      return res.json(Response.get('Check Updated', updateCheck));
+    } catch (error) {
+      res.status(error.status || 500).json({
+        message: error.message || 'Something goes wrong',
+        data: error
+      });
+    }
+  }
+
   static async delete(req, res) {
     try {
       await CheckService.delete({ id: req.params.id, user: req.user });

--- a/src/controllers/CheckController.js
+++ b/src/controllers/CheckController.js
@@ -100,6 +100,21 @@ class CheckController {
     }
   }
 
+  static async disable(req, res) {
+    const { id } = req.params;
+
+    try {
+      const updateCheck = await CheckService.disable({id, user: req.user});
+
+      return res.json(Response.get('Check Updated', updateCheck));
+    } catch (error) {
+      res.status(error.status || 500).json({
+        message: error.message || 'Something goes wrong',
+        data: error
+      });
+    }
+  }
+
   static async delete(req, res) {
     try {
       await CheckService.delete({ id: req.params.id, user: req.user });

--- a/src/routes/Check.js
+++ b/src/routes/Check.js
@@ -8,6 +8,7 @@ router.get('/', verifyToken, CheckController.getAll);
 router.get('/:id', verifyToken, CheckController.getById);
 router.get('/:id/logs', verifyToken, CheckController.getLogsByCheckId);
 router.put('/:id', verifyToken, CheckController.update);
+router.put('/:id/disable', verifyToken, CheckController.disable);
 router.post('/', verifyToken, CheckController.create);
 router.delete('/:id', verifyToken, CheckController.delete);
 

--- a/src/routes/Check.js
+++ b/src/routes/Check.js
@@ -9,6 +9,7 @@ router.get('/:id', verifyToken, CheckController.getById);
 router.get('/:id/logs', verifyToken, CheckController.getLogsByCheckId);
 router.put('/:id', verifyToken, CheckController.update);
 router.put('/:id/disable', verifyToken, CheckController.disable);
+router.put('/:id/enable', verifyToken, CheckController.enable);
 router.post('/', verifyToken, CheckController.create);
 router.delete('/:id', verifyToken, CheckController.delete);
 

--- a/src/services/CheckService.js
+++ b/src/services/CheckService.js
@@ -280,6 +280,11 @@ class CheckService {
       }
 
       await Checks.update({ enabled: true }, { where: { id, userId: user.id } });
+      // stop to avoid cron duplicate
+      this.stopCheck(check);
+      this.stopCheck(check, `${check.id}_retry`);
+
+      // Now run the check
       this.runCheck(check);
       Audit.onUpdate(user, { entity: 'check', old: check, edited: { enabled: true } });
       return check;

--- a/src/services/CheckService.js
+++ b/src/services/CheckService.js
@@ -253,6 +253,24 @@ class CheckService {
     }
   }
 
+  static async disable({id, user}){
+    try {
+      const check = await Checks.findOne({ where: { id, userId: user.id } });
+
+      if (!check) {
+        throw ({ status: 404, message: 'Check not found' });
+      }
+
+      await Checks.update({ enabled: false }, { where: { id, userId: user.id } });
+      this.stopCheck(check);
+      this.stopCheck(check, `${check.id}_retry`);
+      Audit.onUpdate(user, { entity: 'check', old: check, edited: { enabled: false } });
+      return check;
+    } catch (error) {
+      throw error;
+    }
+  }
+
   static async getAll(params) {
     const { criterions } = params;
 

--- a/src/services/CheckService.js
+++ b/src/services/CheckService.js
@@ -271,6 +271,23 @@ class CheckService {
     }
   }
 
+  static async enable({id, user}){
+    try {
+      const check = await Checks.findOne({ where: { id, userId: user.id } });
+
+      if (!check) {
+        throw ({ status: 404, message: 'Check not found' });
+      }
+
+      await Checks.update({ enabled: true }, { where: { id, userId: user.id } });
+      this.runCheck(check);
+      Audit.onUpdate(user, { entity: 'check', old: check, edited: { enabled: true } });
+      return check;
+    } catch (error) {
+      throw error;
+    }
+  }
+
   static async getAll(params) {
     const { criterions } = params;
 


### PR DESCRIPTION
### General
Create endpoints to allow to enable/disable checks without send ping to the check, this is useful when the check is down, and you don't know the time to put back.

[#57](https://github.com/ta-vivo/ta-vivo/issues/57)

### Type

> ℹ️  What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [ ] Fix
- [x] Feature

### Describe the changes here (summarized)
